### PR TITLE
No $guarded Attributes Sniff

### DIFF
--- a/DealerInspireLaravelCodingStandard/Sniffs/Models/NoGuardedAttributesSniff.php
+++ b/DealerInspireLaravelCodingStandard/Sniffs/Models/NoGuardedAttributesSniff.php
@@ -1,0 +1,42 @@
+<?php
+declare(strict_types=1);
+
+namespace DealerInspireLaravelCodingStandard\Sniffs\Models;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+
+/**
+ * NoGuardedAttributesSniff is a class that detects when a class has a protected $guarded attribute.
+ *
+ * @package DealerInspireLaravel\Sniffs\Models
+ */
+class NoGuardedAttributesSniff implements Sniff
+{
+    /**
+     * Returns the token types that this sniff is interested in.
+     *
+     * @return int[]
+     */
+    public function register(): array
+    {
+        return [T_PROTECTED];
+    }
+
+    /**
+     * Processes this sniff, when one of its tokens is encountered.
+     *
+     * @param  File $phpcsFile The current file being checked.
+     * @param  mixed $stackPtr  The position of the current token in the stack passed in $tokens. Type of mixed due to the interface not enforcing int.
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr): void
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        $variablePointer = $phpcsFile->findNext([T_VARIABLE], $stackPtr);
+        if ($tokens[$variablePointer]['content'] === '$guarded') {
+            $phpcsFile->addError('Uses $guarded attributes', $variablePointer, 'GuardedAttributes');
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ Then you can use any of the sniffs provided in this package.
 
 ## Provided Sniffs
 
+### DealerInspireLaravelCodingStandard.Models.NoGuardedAttributes
+
+Checks that no classes use the `protected $guarded` attribute. Useful for any projects that strictly enforce the use of explicitly whitelisting fillable attributes.
+
 ### DealerInspireLaravelCodingStandard.Providers.DeferredProviders
 
 Checks all deferred service providers to ensure that any bindings in the file are also included in the `provides` array.

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "dealerinspire/laravel-coding-standard",
   "description": "DealerInspire Coding Standard for Laravel specific requirements.",
-  "version": "v1.1.0",
+  "version": "v1.2.0",
   "license": "MIT",
   "type": "phpcodesniffer-standard",
   "minimum-stability": "dev",

--- a/tests/Sniffs/Models/NoGuardedAttributesSniffTest.php
+++ b/tests/Sniffs/Models/NoGuardedAttributesSniffTest.php
@@ -1,0 +1,83 @@
+<?php
+declare(strict_types = 1);
+
+namespace DealerInspireLaravel\Sniffs\Models;
+
+use DealerInspireLaravelCodingStandard\Sniffs\Models\NoGuardedAttributesSniff;
+use PHP_CodeSniffer\Config;
+use PHP_CodeSniffer\Files\LocalFile;
+use PHP_CodeSniffer\Runner;
+use PHPUnit\Framework\TestCase;
+
+class NoGuardedAttributesSniffTest extends TestCase
+{
+    /**
+     * @var Runner
+     */
+    protected $codeSniffer;
+
+    public function setUp()
+    {
+        $this->codeSniffer = new Runner();
+        $this->codeSniffer->config = new Config(['-s']);
+        $this->codeSniffer->init();
+
+        $this->codeSniffer->ruleset->sniffs = [NoGuardedAttributesSniff::class => new NoGuardedAttributesSniff()];
+        $this->codeSniffer->ruleset->populateTokenListeners();
+    }
+
+    /**
+     * @var string $fileName           The file that will be checked
+     * @var array  $expectedMessages   The expected error messages where the key is the message and the value is null (for easier comparison)
+     * @dataProvider dataProvider
+     */
+    public function test(string $fileName, array $expectedMessages): void
+    {
+        $file = $this->getFileForPath(__DIR__ . '/data/' . $fileName);
+
+        foreach ($file->getErrors() as $error) {
+            $error = reset($error)[0];
+            $errorMessage = $error['message'];
+            $errorCode = explode('.', $error['source'])[3];
+
+            $this->assertEquals($expectedMessages[$errorCode], $errorMessage);
+        }
+
+        $this->assertSame(count($expectedMessages), $file->getErrorCount());
+    }
+
+    public function dataProvider(): array
+    {
+        return [
+            'Test class with no guarded attributes passes' =>
+                [
+                    'NoGuardedAttributesModel.php',
+                    [],
+                ],
+            'Test class with no guarded attributes that has a $guarded variable passes' =>
+                [
+                    'NoGuardedAttributesWithGuardedVariableModel.php',
+                    [],
+                ],
+            'Test class with guarded attributes fails' =>
+                [
+                    'GuardedAttributesModel.php',
+                    [
+                        'GuardedAttributes' => 'Uses $guarded attributes',
+                    ],
+                ],
+        ];
+    }
+
+    /**
+     * @param string $filePath Get a File object for the given path using the ruleset under test
+     * @return LocalFile
+     */
+    protected function getFileForPath(string $filePath): LocalFile
+    {
+        $file = new LocalFile($filePath, $this->codeSniffer->ruleset, $this->codeSniffer->config);
+
+        $file->process();
+        return $file;
+    }
+}

--- a/tests/Sniffs/Models/data/GuardedAttributesModel.php
+++ b/tests/Sniffs/Models/data/GuardedAttributesModel.php
@@ -1,0 +1,15 @@
+<?php
+declare(strict_types=1);
+
+namespace App;
+
+class GuardedAttributesModel
+{
+    protected $attribute = 'value';
+
+    protected $guarded = [
+        'id',
+    ];
+
+    public function SomeFunction() {}
+}

--- a/tests/Sniffs/Models/data/NoGuardedAttributesModel.php
+++ b/tests/Sniffs/Models/data/NoGuardedAttributesModel.php
@@ -1,0 +1,11 @@
+<?php
+declare(strict_types=1);
+
+namespace App;
+
+class NoGuardedAttributesModel
+{
+    protected $attribute = 'value';
+
+    public function SomeFunction() {}
+}

--- a/tests/Sniffs/Models/data/NoGuardedAttributesWithGuardedVariableModel.php
+++ b/tests/Sniffs/Models/data/NoGuardedAttributesWithGuardedVariableModel.php
@@ -1,0 +1,13 @@
+<?php
+declare(strict_types=1);
+
+namespace App;
+
+class NoGuardedAttributesWithGuardedVariableModel
+{
+    protected $attribute = 'value';
+
+    public function SomeFunction() {
+        $guarded = 'not this';
+    }
+}


### PR DESCRIPTION
This PR adds a `Models\NoGuardedAttributes` sniff, which simply checks for any `protected $guarded` attributes on classes and fails if it finds it. This would resolve #7.