### PR TITLE
Add Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: php
 php:
   - 7.2
   - 7.3
-  - nightly
 script:
   - composer install
   - ./bin/phpunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: php
+php:
+  - 7.2
+  - 7.3
+  - nightly
+script:
+  - composer install
+  - ./bin/phpunit

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Laravel Coding Standard
 
+[![Build Status][travis-badge]][travis-home]
+
 Dealer Inspire Laravel Coding Standard provides sniffs that help developers write better Laravel code.
 
 ## Installation
@@ -37,3 +39,6 @@ Checks all deferred service providers to ensure that any bindings in the file ar
 ## License
 
 MIT © [Dealer Inspire](https://www.dealerinspire.com/)
+
+[travis-home]:https://travis-ci.com/jpuck/laravel-coding-standard
+[travis-badge]:https://travis-ci.com/jpuck/laravel-coding-standard.svg?branch=master

--- a/README.md
+++ b/README.md
@@ -40,5 +40,5 @@ Checks all deferred service providers to ensure that any bindings in the file ar
 
 MIT © [Dealer Inspire](https://www.dealerinspire.com/)
 
-[travis-home]:https://travis-ci.com/jpuck/laravel-coding-standard
-[travis-badge]:https://travis-ci.com/jpuck/laravel-coding-standard.svg?branch=master
+[travis-home]:https://travis-ci.com/dealerinspire/laravel-coding-standard
+[travis-badge]:https://travis-ci.com/dealerinspire/laravel-coding-standard.svg?branch=master

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -9,6 +9,11 @@
         beStrictAboutTodoAnnotatedTests="true"
         executionOrder="defects"
 >
+    <testsuites>
+        <testsuite name="Unit">
+            <directory suffix="Test.php">./tests</directory>
+        </testsuite>
+    </testsuites>
     <filter>
         <whitelist processUncoveredFilesFromWhitelist="true">
             <directory suffix=".php">DealerInspireLaravelCodingStandard</directory>


### PR DESCRIPTION
https://travis-ci.com has always been very good to open source.

This will allow us to see at a glance whether a PR is passing or failing the test suite, without having to pull it down locally to test.

Mutually, this will also provide transparent visibility to others of the build status: [![Build Status][travis-badge]][travis-home] (click on that badge to see the public builds for this branch)

[travis-home]:https://travis-ci.com/jpuck/laravel-coding-standard
[travis-badge]:https://travis-ci.com/jpuck/laravel-coding-standard.svg?branch=travis
