### PR TITLE
Change detection to look for extending ServiceProvider

### DIFF
--- a/tests/Sniffs/Providers/DeferredProvidersSniffTest.php
+++ b/tests/Sniffs/Providers/DeferredProvidersSniffTest.php
@@ -76,6 +76,22 @@ class DeferredProvidersSniffTest extends TestCase
                     'NotDeferredServiceProvider.php',
                     [],
                 ],
+            'Test $defers fails if provider extends ServiceProvider but class name does not end with ServiceProvider' =>
+                [
+                    'DeferredWithDefersWithoutServiceProviderClassName.php',
+                    [
+                        'Found unbound class in provides "AnotherServiceContract::class"' => null,
+                        'Found bound class not in provides "SomeServiceContract::class"' => null,
+                    ]
+                ],
+            'Test DeferrableProvider fails if provider extends ServiceProvider but class name does not end with ServiceProvider' =>
+                [
+                    'DeferredWithDefersWithoutServiceProviderClassName.php',
+                    [
+                        'Found unbound class in provides "AnotherServiceContract::class"' => null,
+                        'Found bound class not in provides "SomeServiceContract::class"' => null,
+                    ]
+                ],
             'Test deferred with class property define and string provides fails' =>
                 [
                     'DeferredWithClassPropertyVsStringServiceProvider.php',

--- a/tests/Sniffs/Providers/data/DeferredImplementsWithoutServiceProviderClassName.php
+++ b/tests/Sniffs/Providers/data/DeferredImplementsWithoutServiceProviderClassName.php
@@ -1,0 +1,27 @@
+<?php
+declare(strict_types=1);
+
+class SomeProviderClass extends ServiceProvider implements DeferrableProvider
+{
+    /**
+     * Register the application services.
+     *
+     * @return void
+     */
+    public function register(): void
+    {
+        $this->app->bind(SomeServiceContract::class, function () {
+            return new SomeService();
+        });
+    }
+
+    /**
+     * @return array the provided contracts for this deferred provider
+     */
+    public function provides(): array
+    {
+        return [
+            AnotherServiceContract::class,
+        ];
+    }
+}

--- a/tests/Sniffs/Providers/data/DeferredWithDefersWithoutServiceProviderClassName.php
+++ b/tests/Sniffs/Providers/data/DeferredWithDefersWithoutServiceProviderClassName.php
@@ -1,0 +1,32 @@
+<?php
+declare(strict_types=1);
+
+class SomeProviderClass extends ServiceProvider
+{
+    /**
+     * @var bool true defer till needed
+     */
+    protected $defer = true;
+
+    /**
+     * Register the application services.
+     *
+     * @return void
+     */
+    public function register(): void
+    {
+        $this->app->bind(SomeServiceContract::class, function () {
+            return new SomeService();
+        });
+    }
+
+    /**
+     * @return array the provided contracts for this deferred provider
+     */
+    public function provides(): array
+    {
+        return [
+            AnotherServiceContract::class,
+        ];
+    }
+}


### PR DESCRIPTION
This would resolve #4 by looking for classes that extend "ServiceProvider" instead of just classes where the class name ends in "ServiceProvider"

This is a breaking change (right now because I'm scrapping the original detection method, or if I kept that detection method this would still be a breaking change because it might start detecting more classes than before and break people's CS checks) so this will need to released as v2 if it gets merged.